### PR TITLE
Change mrtrix mamba env to compile from github tag 3.0.4

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -13,3 +13,6 @@ fsl_version: 6.0.7.13
 
 # https://surfer.nmr.mgh.harvard.edu/fswiki/rel7downloads
 freesurfer_version: 7.4.1
+
+# https://github.com/MRtrix3/mrtrix3/releases
+mrtrix3_version: 3.0.4

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -17,6 +17,7 @@
     autoremove: true
     pkg:
       - python3
+      - python-is-python3
       - libeigen3-dev
       - zlib1g-dev
       - libqt5opengl5-dev
@@ -25,7 +26,8 @@
       - libfftw3-dev
       - libtiff5-dev
       - libpng-dev
-
+      - git
+      - g++
 
 - name: Git checkout mrtrix3
   ansible.builtin.git:

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -1,4 +1,14 @@
 ---
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - /opt/quarantine/software/mrtrix3/3.0.4
+    - /opt/quarantine/software/mrtrix3tissue/5.2.9
+
+
 - name: Install mtrix3 dependencies
   ansible.builtin.apt:
     update_cache: true
@@ -15,15 +25,6 @@
       - libfftw3-dev
       - libtiff5-dev
       - libpng-dev
-
-
-- name: Create directories
-  file:
-    path: "{{ item }}"
-    state: directory
-  loop:
-    - /opt/quarantine/software/mrtrix3/3.0.4
-    - /opt/quarantine/software/mrtrix3tissue/5.2.9
 
 
 - name: Git checkout mrtrix3

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -32,7 +32,7 @@
   ansible.builtin.git:
     repo: https://github.com/MRtrix3/mrtrix3
     dest: /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}/install
-    version: {{ mrtrix3_version }}
+    version: "{{ mrtrix3_version }}"
 
 - name: Build mrtrix3
   shell: ./configure && ./build

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -4,7 +4,7 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - /opt/quarantine/software/mrtrix3/3.0.4
+    - /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}
     - /opt/quarantine/software/mrtrix3tissue/5.2.9
 
 
@@ -31,19 +31,19 @@
 - name: Git checkout mrtrix3
   ansible.builtin.git:
     repo: https://github.com/MRtrix3/mrtrix3
-    dest: /opt/quarantine/software/mrtrix3/3.0.4/install
-    version: 3.0.4
+    dest: /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}/install
+    version: {{ mrtrix3_version }}
 
 - name: Build mrtrix3
   shell: ./configure && ./build
   args:
-    creates: /opt/quarantine/software/mrtrix3/3.0.4/install/bin/mrview
-    chdir: /opt/quarantine/software/mrtrix3/3.0.4/install
+    creates: /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}/install/bin/mrview
+    chdir: /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}/install
 
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/mrtrix3/3.0.4/module
+    dest: /opt/quarantine/software/mrtrix3/{{ mrtrix3_version }}/module
   notify: link modules
 
 

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create directories
   file:
     path: "{{ item }}"

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -1,26 +1,5 @@
 ---
-- name: Create directories
-  file:
-    path: "{{ item }}"
-    state: directory
-  loop:
-    - /opt/quarantine/software/mrtrix3/3.0.4
-    - /opt/quarantine/software/mrtrix3tissue/5.2.9
-
-- name: install mrtrix3
-  shell: micromamba create --quiet --yes -c mrtrix3 -c conda-forge -p /opt/quarantine/software/mrtrix3/3.0.4/mrtrix3 mrtrix3=3.0.4
-  args:
-    creates: /opt/quarantine/software/mrtrix3/3.0.4/mrtrix3/bin/mrcalc
-
-- name: Install module
-  template:
-    src: templates/conda_module.j2
-    dest: /opt/quarantine/software/mrtrix3/3.0.4/module
-  vars:
-    modulename: mrtrix3
-  notify: link modules
-
-- name: Install mtrix3tissue dependencies
+- name: Install mtrix3 dependencies
   ansible.builtin.apt:
     update_cache: true
     state: present
@@ -36,6 +15,35 @@
       - libfftw3-dev
       - libtiff5-dev
       - libpng-dev
+
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - /opt/quarantine/software/mrtrix3/3.0.4
+    - /opt/quarantine/software/mrtrix3tissue/5.2.9
+
+
+- name: Git checkout mrtrix3
+  ansible.builtin.git:
+    repo: https://github.com/MRtrix3/mrtrix3
+    dest: /opt/quarantine/software/mrtrix3/3.0.4/install
+    version: 3.0.4
+
+- name: Build mrtrix3
+  shell: ./configure && ./build
+  args:
+    creates: /opt/quarantine/software/mrtrix3/3.0.4/install/bin/mrview
+    chdir: /opt/quarantine/software/mrtrix3/3.0.4/install
+
+- name: Install module
+  template:
+    src: templates/basemodule.j2
+    dest: /opt/quarantine/software/mrtrix3/3.0.4/module
+  notify: link modules
+
 
 - name: Git checkout mrtrix3tissue
   ansible.builtin.git:

--- a/roles/science/tasks/mrtrix.yml
+++ b/roles/science/tasks/mrtrix.yml
@@ -8,7 +8,7 @@
     - /opt/quarantine/software/mrtrix3tissue/5.2.9
 
 
-- name: Install mtrix3 dependencies
+- name: Install mrtrix3 dependencies
   ansible.builtin.apt:
     update_cache: true
     state: present


### PR DESCRIPTION
Compiles mrtrix from github tag 3.0.4 instead of mamba enviroment (that is not properly working for ubuntu 24.04). 