### PR TITLE
Update software versions 2026Q1

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -15,7 +15,7 @@ fsl_version: 6.0.7.21
 freesurfer_version: 7.4.1
 
 # https://github.com/MRtrix3/mrtrix3/releases
-mrtrix3_version: 3.0.5
+mrtrix3_version: 3.0.8
 
 # https://github.com/MRtrix3/mrtrix3.git . Compile latest commit in main
 mrtrix3_dev_version: "{{ (lookup('ansible.builtin.url', 'https://api.github.com/repos/MRtrix3/mrtrix3/commits/HEAD', wantlist=True)[0] | from_json).commit.committer.date | regex_replace('T.*', '') | regex_replace('-','') }}"

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,6 +1,6 @@
 ---
 # https://github.com/ANTsX/ANTs/releases
-ants_version: 2.6.2
+ants_version: 2.6.5
 
 # Automatic lookup online
 afni_version: "{{ lookup('ansible.builtin.url', 'https://afni.nimh.nih.gov/pub/dist/AFNI.version', wantlist=True)[0] | regex_replace('AFNI_', '')  }}"

--- a/group_vars/all
+++ b/group_vars/all
@@ -9,7 +9,7 @@ afni_version: "{{ lookup('ansible.builtin.url', 'https://afni.nimh.nih.gov/pub/d
 fastsurfer_version: 2.4.2
 
 # https://fsl.fmrib.ox.ac.uk/fsl/docs/#/development/history/index
-fsl_version: 6.0.7.13
+fsl_version: 6.0.7.21
 
 # https://surfer.nmr.mgh.harvard.edu/fswiki/rel7downloads
 freesurfer_version: 7.4.1

--- a/group_vars/all
+++ b/group_vars/all
@@ -13,6 +13,7 @@ fsl_version: 6.0.7.21
 
 # https://surfer.nmr.mgh.harvard.edu/fswiki/rel7downloads
 freesurfer_version: 7.4.1
+freesurfer_version_v8: 8.1.0
 
 # https://github.com/MRtrix3/mrtrix3/releases
 mrtrix3_version: 3.0.8

--- a/roles/science/tasks/cobralab.yml
+++ b/roles/science/tasks/cobralab.yml
@@ -8,7 +8,7 @@
     - /opt/quarantine/software/iterativeN3/20230821
     - /opt/quarantine/software/iterativeN4_multispectral/20210503
     - /opt/quarantine/software/minc-bpipe-library/20230721
-    - /opt/quarantine/software/bpipe/0.9.12/install
+    - /opt/quarantine/software/bpipe/0.9.13/install
 
 - name: clone minc-toolkit-extras
   ansible.builtin.git:
@@ -77,9 +77,9 @@
 
 - name: install bpipe
   unarchive:
-    src: https://github.com/ssadedin/bpipe/releases/download/0.9.12/bpipe-0.9.12.tar.gz
-    dest: /opt/quarantine/software/bpipe/0.9.12/install
-    creates: /opt/quarantine/software/bpipe/0.9.12/install/bin/bpipe
+    src: https://github.com/ssadedin/bpipe/releases/download/0.9.13/bpipe-0.9.13.tar.gz
+    dest: /opt/quarantine/software/bpipe/0.9.13/install
+    creates: /opt/quarantine/software/bpipe/0.9.13/install/bin/bpipe
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -88,5 +88,5 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/bpipe/0.9.12/module
+    dest: /opt/quarantine/software/bpipe/0.9.13/module
   notify: link modules

--- a/roles/science/tasks/containers.yml
+++ b/roles/science/tasks/containers.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Install software-properties-common for apt-add-repository
+  ansible.builtin.apt:
+    name: software-properties-common
+    state: present
+    update_cache: true
+
 - name: add apptainer ppa
   command: apt-add-repository -y -n {{ item }}
   with_items:

--- a/roles/science/tasks/fmriprep.yml
+++ b/roles/science/tasks/fmriprep.yml
@@ -7,6 +7,7 @@
     - /opt/quarantine/software/fmriprep/24.1.1/install
     - /opt/quarantine/software/fmriprep/20.2.8/install
     - /opt/quarantine/software/fmriprep/25.2.3/install
+    - /opt/quarantine/software/fmriprep/25.2.5/install
 
 
 - name: Build fmriprep singularity container
@@ -31,6 +32,17 @@
     dest: /opt/quarantine/software/fmriprep/25.2.3/module
   notify: link modules
 
+
+- name: Build fmriprep singularity container
+  command: apptainer build /opt/quarantine/software/fmriprep/25.2.5/install/fmriprep docker://nipreps/fmriprep:25.2.5
+  args:
+    creates: /opt/quarantine/software/fmriprep/25.2.5/install/fmriprep
+
+- name: Install module
+  template:
+    src: templates/basemodule.j2
+    dest: /opt/quarantine/software/fmriprep/25.2.5/module
+  notify: link modules
 #######LTS Version
 
 - name: Build fmriprep singularity container

--- a/roles/science/tasks/freesurfer.yml
+++ b/roles/science/tasks/freesurfer.yml
@@ -24,6 +24,7 @@
   vars:
     extra_opts:
       - conflict("minc-toolkit-v2")
+      - conflict("freesurfer/8.1.0")
       - prepend_path("PATH", pathJoin(basepath,"fsfast/bin"))
       - prepend_path("PATH", pathJoin(basepath,"tktools"))
       - prepend_path("PATH", pathJoin(basepath,"mni/bin"))
@@ -50,3 +51,65 @@
     src: files/license.txt
     dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version }}1/install/license.txt"
   ignore_errors: true
+
+
+###############################################################################
+# FreeSurfer 8.1.0 (separate installation from 7.4.1)
+###############################################################################
+
+- name: Create freesurfer 8.1.0 directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src"
+    - "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install"
+
+- name: Download freesurfer 8.1.0 deb
+  ansible.builtin.get_url:
+    url: "https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/8.1.0/freesurfer_ubuntu22-8.1.0_amd64.deb"
+    dest: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src
+
+- name: Extract freesurfer 8.1.0 deb to install directory
+  shell: >
+      dpkg -x freesurfer_ubuntu22-8.1.0_amd64.deb /tmp/fs8temp
+      && mv /tmp/fs8temp/usr/local/freesurfer/* /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install
+      && rm -rf /tmp/fs8temp
+  args:
+    chdir: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src
+    creates: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install/SetUpFreeSurfer.sh
+    executable: /bin/bash
+
+- name: Install module
+  template:
+    src: templates/basemodule.j2
+    dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/module"
+  vars:
+    extra_opts:
+      - conflict("minc-toolkit-v2")
+      - conflict("freesurfer/7.4.1")
+      - prepend_path("PATH", pathJoin(basepath,"fsfast/bin"))
+      - prepend_path("PATH", pathJoin(basepath,"tktools"))
+      - prepend_path("PATH", pathJoin(basepath,"mni/bin"))
+      - setenv("MINC_BIN_DIR", pathJoin(basepath,"mni/bin"))
+      - setenv("FSFAST_HOME", pathJoin(basepath,"fsfast"))
+      - setenv("FREESURFER", basepath)
+      - setenv("FREESURFER_HOME", basepath)
+      - setenv("MNI_DATAPATH", pathJoin(basepath,"mni/data"))
+      - setenv("FS_OVERRIDE", "0")
+      - setenv("FUNCTIONALS_DIR", pathJoin(basepath,"sessions"))
+      - setenv("MINC_LIB_DIR", pathJoin(basepath,"mni/lib"))
+      - setenv("FMRI_ANALYSIS_DIR", pathJoin(basepath,"fsfast"))
+      - setenv("MNI_DIR", pathJoin(basepath,"mni"))
+      - prepend_path("PERL5LIB", pathJoin(basepath,"mni/share/perl5"))
+      - setenv("MNI_PERL5LIB", pathJoin(basepath,"mni/share/perl5"))
+      - setenv("LOCAL_DIR", pathJoin(basepath,"local"))
+      - setenv("FIX_VERTEX_AREA", "")
+      - setenv("SUBJECTS_DIR", pathJoin(basepath,"subjects"))
+      - setenv("FSF_OUTPUT_FORMAT", "nii.gz")
+  notify: link modules
+
+- name: Cleanup freesurfer 8.1.0 downloaded deb
+  ansible.builtin.file:
+    path: "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src"
+    state: absent

--- a/roles/science/tasks/fsl.yml
+++ b/roles/science/tasks/fsl.yml
@@ -14,7 +14,7 @@
     dest: "/opt/quarantine/software/fsl/{{ fsl_version }}/src/fslinstaller.py"
 
 - name: install fsl
-  shell: "python /opt/quarantine/software/fsl/{{ fsl_version }}/src/fslinstaller.py --dest /opt/quarantine/software/fsl/{{ fsl_version }}/install --fslversion {{ fsl_version }} --no_env --overwrite"
+  shell: "python3 /opt/quarantine/software/fsl/{{ fsl_version }}/src/fslinstaller.py --dest /opt/quarantine/software/fsl/{{ fsl_version }}/install --fslversion {{ fsl_version }} --no_env --overwrite"
   args:
     creates: "/opt/quarantine/software/fsl/{{ fsl_version }}/install/LICENCE.FSL"
 

--- a/roles/science/tasks/matlab-modules.yml
+++ b/roles/science/tasks/matlab-modules.yml
@@ -6,7 +6,7 @@
   loop:
     - /opt/quarantine/software/PLS/6.15/install
     - /opt/quarantine/software/SPM12/r7771/install
-    - /opt/quarantine/software/CAT12/12.8.2/install
+    - /opt/quarantine/software/CAT12/12.9/install
     - /opt/quarantine/software/BrainNetViewer/1.7/install
 
 - name: Download MATLAB PLS
@@ -53,9 +53,9 @@
 
 - name: Download SPM
   unarchive:
-    src: https://github.com/ChristianGaser/cat12/releases/download/12.8.2/cat12.8.2.zip
-    dest: /opt/quarantine/software/CAT12/12.8.2/install
-    creates: /opt/quarantine/software/CAT12/12.8.2/install/cat12
+    src: https://github.com/ChristianGaser/cat12/releases/download/12.9/cat12.9.zip
+    dest: /opt/quarantine/software/CAT12/12.9/install
+    creates: /opt/quarantine/software/CAT12/12.9/install/cat12
     remote_src: yes
     extra_opts:
       - --no-same-owner  # Prevent chown issues in Docker
@@ -63,7 +63,7 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/CAT12/12.8.2/module
+    dest: /opt/quarantine/software/CAT12/12.9/module
   vars:
     prereqs:
       - MATLAB
@@ -78,7 +78,7 @@
     content: |
               global defaults
               defaults.tbx.dir{end+1} = fullfile(fileparts(mfilename('fullpath')),"CAT12") ;
-    dest: /opt/quarantine/software/CAT12/12.8.2/install/spm_my_defaults.m
+    dest: /opt/quarantine/software/CAT12/12.9/install/spm_my_defaults.m
 
 - name: Download BrainNetViewer
   unarchive:

--- a/roles/science/tasks/minc.yml
+++ b/roles/science/tasks/minc.yml
@@ -33,6 +33,7 @@
       - libjpeg-dev
       - libssl-dev
       - zlib1g-dev
+      - cmake
       - automake
       - cpanminus
       - patchelf

--- a/roles/science/tasks/minc.yml
+++ b/roles/science/tasks/minc.yml
@@ -7,7 +7,7 @@
     - /opt/quarantine/software/minc-toolkit-v2/1.9.18/install
     - /opt/quarantine/software/minc-toolkit-v2/1.9.18/src
     - /opt/quarantine/software/minc-stuffs/v0.1.25
-    - /opt/quarantine/software/minc2-simple/v2.2.30/build
+    - /opt/quarantine/software/minc2-simple/v2.20.40/build
 
 - name: Install minc-toolkit-v2 build deps
   apt:
@@ -121,12 +121,12 @@
 
 - name: clone minc2-simple
   git:
-    repo: https://github.com/vfonov/minc2-simple.git
-    dest: /opt/quarantine/software/minc2-simple/v2.2.30/src
-    version: v2.2.30
+    repo: https://github.com/NIST-MNI/minc2-simple.git
+    dest: /opt/quarantine/software/minc2-simple/v2.20.40/src
+    version: v2.20.40
 
 - name: Install minc2-simple (python)
-  shell: MINC_TOOLKIT=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install micromamba run -r /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base pip install /opt/quarantine/software/minc2-simple/v2.2.30/src/python
+  shell: MINC_TOOLKIT=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install micromamba run -r /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base pip install /opt/quarantine/software/minc2-simple/v2.20.40/src/python
   args:
     creates: /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base/lib/python3.11/site-packages/minc2_simple
   when:
@@ -135,7 +135,7 @@
 - name: Install minc2-simple (C)
   shell: cmake -DCMAKE_INSTALL_PREFIX=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install ../src && make -j {{ ansible_processor_vcpus }} && make install
   args:
-    chdir: /opt/quarantine/software/minc2-simple/v2.2.30/build
+    chdir: /opt/quarantine/software/minc2-simple/v2.20.40/build
     creates: /opt/quarantine/software/minc-toolkit-v2/1.9.18/install/lib/libminc2-simple.so
     executable: /bin/bash
 

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -9,7 +9,7 @@
     - /opt/quarantine/software/3DSlicer/5.10.0/install
     - /opt/quarantine/software/MRIcron/v1.2.20211006/install
     - /opt/quarantine/software/MRIcroGL/v1.2.20220720/install
-    - /opt/quarantine/software/dcm2niix/v1.0.20240202/install
+    - /opt/quarantine/software/dcm2niix/v1.0.20250506/install
     - /opt/quarantine/software/mi-brain/2020.04.09_r2e0ff5/install
     - /opt/quarantine/software/mango/4.1/install
     - /opt/quarantine/software/connectome-workbench/v1.5.0/install
@@ -116,9 +116,9 @@
 
 - name: Install dcm2niix
   unarchive:
-    src: https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20240202/dcm2niix_lnx.zip
-    dest: /opt/quarantine/software/dcm2niix/v1.0.20240202/install
-    creates:  /opt/quarantine/software/dcm2niix/v1.0.20240202/install/dcm2niix
+    src: https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20250506/dcm2niix_lnx.zip
+    dest: /opt/quarantine/software/dcm2niix/v1.0.20250506/install
+    creates:  /opt/quarantine/software/dcm2niix/v1.0.20250506/install/dcm2niix
     remote_src: yes
 
     extra_opts:
@@ -126,7 +126,7 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/dcm2niix/v1.0.20240202/module
+    dest: /opt/quarantine/software/dcm2niix/v1.0.20250506/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -5,7 +5,7 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - /opt/quarantine/software/itk-snap/4.2.0/install
+    - /opt/quarantine/software/itk-snap/4.4.0/install
     - /opt/quarantine/software/3DSlicer/5.6.2/install
     - /opt/quarantine/software/MRIcron/v1.2.20211006/install
     - /opt/quarantine/software/MRIcroGL/v1.2.20220720/install
@@ -44,9 +44,9 @@
 
 - name: Install itk-snap
   unarchive:
-    src: https://downloads.sourceforge.net/project/itk-snap/itk-snap/4.2.0/itksnap-4.2.0-20240422-Linux-gcc64.tar.gz
-    dest: /opt/quarantine/software/itk-snap/4.2.0/install
-    creates:  /opt/quarantine/software/itk-snap/4.2.0/install/bin/itksnap
+    src: https://downloads.sourceforge.net/project/itk-snap/itk-snap/4.4.0/itksnap-4.4.0-20250909-Linux-x86_64.tar.gz
+    dest: /opt/quarantine/software/itk-snap/4.4.0/install
+    creates:  /opt/quarantine/software/itk-snap/4.4.0/install/bin/itksnap
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -55,7 +55,7 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/itk-snap/4.2.0/module
+    dest: /opt/quarantine/software/itk-snap/4.4.0/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -14,7 +14,7 @@
     - /opt/quarantine/software/mango/4.1/install
     - /opt/quarantine/software/connectome-workbench/v1.5.0/install
     - /opt/quarantine/software/connectome-workbench/v2.0.0/install
-    - /opt/quarantine/software/dsi-studio/2023.12.06/install
+    - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
     - /opt/quarantine/software/dcm2bids/3.1.1/install
     - /opt/quarantine/software/bpipe/0.9.12/install
@@ -210,17 +210,17 @@
 - name: Install dsi-studio
   ansible.builtin.shell: |
       curl -s -L -o /tmp/dsi_studio_ubuntu2204.zip \
-      https://github.com/frankyeh/DSI-Studio/releases/download/2023.12.06/dsi_studio_ubuntu2204.zip
-      bsdtar xzvf /tmp/dsi_studio_ubuntu2204.zip --strip-components 1 -C /opt/quarantine/software/dsi-studio/2023.12.06/install
+      https://github.com/frankyeh/DSI-Studio/releases/download/2025.04.16/dsi_studio_ubuntu2204.zip
+      bsdtar xzvf /tmp/dsi_studio_ubuntu2204.zip --strip-components 1 -C /opt/quarantine/software/dsi-studio/2025.04.16/install
       rm -f /tmp/dsi_studio_ubuntu2204.zip
   args:
-    creates: /opt/quarantine/software/dsi-studio/2023.12.06/install/dsi_studio
+    creates: /opt/quarantine/software/dsi-studio/2025.04.16/install/dsi_studio
     executable: /bin/bash
 
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/dsi-studio/2023.12.06/module
+    dest: /opt/quarantine/software/dsi-studio/2025.04.16/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -15,7 +15,7 @@
     - /opt/quarantine/software/connectome-workbench/v2.1.0/install
     - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
-    - /opt/quarantine/software/dcm2bids/3.1.1/install
+    - /opt/quarantine/software/dcm2bids/3.2.0/install
     - /opt/quarantine/software/bpipe/0.9.12/install
 
 ###############################################################################
@@ -222,9 +222,9 @@
 
 - name: Install dcm2bids
   unarchive:
-    src: https://github.com/UNFmontreal/Dcm2Bids/releases/download/3.1.1/dcm2bids_debian-based_3.1.1.tar.gz
-    dest: /opt/quarantine/software/dcm2bids/3.1.1/install
-    creates: /opt/quarantine/software/dcm2bids/3.1.1/install/bin
+    src: https://github.com/UNFmontreal/Dcm2Bids/releases/download/3.2.0/dcm2bids_debian-based_3.2.0.tar.gz
+    dest: /opt/quarantine/software/dcm2bids/3.2.0/install
+    creates: /opt/quarantine/software/dcm2bids/3.2.0/install/bin
     remote_src: yes
 
     extra_opts:
@@ -232,7 +232,7 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/dcm2bids/3.1.1/module
+    dest: /opt/quarantine/software/dcm2bids/3.2.0/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -12,8 +12,7 @@
     - /opt/quarantine/software/dcm2niix/v1.0.20250506/install
     - /opt/quarantine/software/mi-brain/2020.04.09_r2e0ff5/install
     - /opt/quarantine/software/mango/4.1/install
-    - /opt/quarantine/software/connectome-workbench/v1.5.0/install
-    - /opt/quarantine/software/connectome-workbench/v2.0.0/install
+    - /opt/quarantine/software/connectome-workbench/v2.1.0/install
     - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
     - /opt/quarantine/software/dcm2bids/3.1.1/install
@@ -165,44 +164,22 @@
     dest: /opt/quarantine/software/mango/4.1/module
   notify: link modules
 
-###############################################################################
-
 - name: Install connectome-workbench
   ansible.builtin.shell: |
-      curl -s -L -o /tmp/workbench-linux64-v1.5.0.zip \
-      https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip
-      bsdtar xzvf /tmp/workbench-linux64-v1.5.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v1.5.0/install
-      rm -f /tmp/workbench-linux64-v1.5.0.zip
-      ln -srf /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin
-      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v1.5.0/install
+      curl -s -L -o /tmp/workbench-linux64-v2.1.0.zip \
+      https://humanconnectome.org/storage/app/media/workbench/workbench-linux64-v2.1.0.zip
+      bsdtar xzvf /tmp/workbench-linux64-v2.1.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v2.1.0/install
+      rm -f /tmp/workbench-linux64-v2.1.0.zip
+      ln -srf /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin
+      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v2.1.0/install
   args:
-    creates: /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin
+    creates: /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin
     executable: /bin/bash
 
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/connectome-workbench/v1.5.0/module
-  notify: link modules
-
-###############################################################################
-
-- name: Install connectome-workbench
-  ansible.builtin.shell: |
-      curl -s -L -o /tmp/workbench-linux64-v2.0.0.zip \
-      https://humanconnectome.org/storage/app/media/workbench/workbench-linux64-v2.0.0.zip
-      bsdtar xzvf /tmp/workbench-linux64-v2.0.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v2.0.0/install
-      rm -f /tmp/workbench-linux64-v2.0.0.zip
-      ln -srf /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin
-      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v1.5.0/install
-  args:
-    creates: /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin
-    executable: /bin/bash
-
-- name: Install module
-  template:
-    src: templates/basemodule.j2
-    dest: /opt/quarantine/software/connectome-workbench/v2.0.0/module
+    dest: /opt/quarantine/software/connectome-workbench/v2.1.0/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -6,7 +6,7 @@
     state: directory
   loop:
     - /opt/quarantine/software/itk-snap/4.4.0/install
-    - /opt/quarantine/software/3DSlicer/5.6.2/install
+    - /opt/quarantine/software/3DSlicer/5.10.0/install
     - /opt/quarantine/software/MRIcron/v1.2.20211006/install
     - /opt/quarantine/software/MRIcroGL/v1.2.20220720/install
     - /opt/quarantine/software/dcm2niix/v1.0.20240202/install
@@ -62,9 +62,9 @@
 
 - name: Install 3DSlicer
   unarchive:
-    src: https://download.slicer.org/bitstream/660f92ed30e435b0e355f1a4
-    dest: /opt/quarantine/software/3DSlicer/5.6.2/install
-    creates: /opt/quarantine/software/3DSlicer/5.6.2/install/Slicer
+    src: https://download.slicer.org/bitstream/6911b598ac7b1c95e7934427
+    dest: /opt/quarantine/software/3DSlicer/5.10.0/install
+    creates: /opt/quarantine/software/3DSlicer/5.10.0/install/Slicer
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -73,7 +73,7 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/3DSlicer/5.6.2/module
+    dest: /opt/quarantine/software/3DSlicer/5.10.0/module
   notify: link modules
 
 ###############################################################################

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -16,7 +16,7 @@
     - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
     - /opt/quarantine/software/dcm2bids/3.2.0/install
-    - /opt/quarantine/software/bpipe/0.9.12/install
+    - /opt/quarantine/software/bpipe/0.9.13/install
 
 ###############################################################################
 
@@ -239,9 +239,9 @@
 
 - name: Install bpipe
   unarchive:
-    src: https://github.com/ssadedin/bpipe/releases/download/0.9.12/bpipe-0.9.12-groovy-3.0.10.tar.gz
-    dest: /opt/quarantine/software/bpipe/0.9.12/install
-    creates: /opt/quarantine/software/bpipe/0.9.12/install/bin/bpipe
+    src: https://github.com/ssadedin/bpipe/releases/download/0.9.13/bpipe-0.9.13.tar.gz
+    dest: /opt/quarantine/software/bpipe/0.9.13/install
+    creates: /opt/quarantine/software/bpipe/0.9.13/install/bin/bpipe
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -250,5 +250,5 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/bpipe/0.9.12/module
+    dest: /opt/quarantine/software/bpipe/0.9.13/module
   notify: link modules

--- a/roles/science/tasks/nvidia.yml
+++ b/roles/science/tasks/nvidia.yml
@@ -4,7 +4,7 @@
     path: "{{ item }}"
     state: directory
   loop:
-    - /opt/quarantine/software/nvhpc/24.3/src
+    - /opt/quarantine/software/nvhpc/26.3/src
 
 - name: Install nvidia development dependencies
   ansible.builtin.apt:
@@ -25,22 +25,22 @@
 
 - name: Download nvhpc
   unarchive:
-    src: https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_x86_64_cuda_multi.tar.gz
-    dest: /opt/quarantine/software/nvhpc/24.3/src
-    creates: /opt/quarantine/software/nvhpc/24.3/install/modulefiles # We rely on a file created by the installation so this isn't re-downloaded
+    src: https://developer.download.nvidia.com/hpc-sdk/26.3/nvhpc_2026_263_Linux_x86_64_cuda_multi.tar.gz
+    dest: /opt/quarantine/software/nvhpc/26.3/src
+    creates: /opt/quarantine/software/nvhpc/26.3/install/modulefiles # We rely on a file created by the installation so this isn't re-downloaded
     remote_src: yes
     extra_opts:
       - --strip-components=1
       - --no-same-owner  # Prevent chown issues in Docker
 
 - name: Run nvhpc Installer
-  ansible.builtin.shell: NVHPC_SILENT=true NVHPC_INSTALL_DIR=/opt/quarantine/software/nvhpc/24.3/install NVHPC_INSTALL_TYPE=auto /opt/quarantine/software/nvhpc/24.3/src/install
+  ansible.builtin.shell: NVHPC_SILENT=true NVHPC_INSTALL_DIR=/opt/quarantine/software/nvhpc/26.3/install NVHPC_INSTALL_TYPE=auto /opt/quarantine/software/nvhpc/26.3/src/install
   args:
-    creates: /opt/quarantine/software/nvhpc/24.3/install/modulefiles
+    creates: /opt/quarantine/software/nvhpc/26.3/install/modulefiles
 
 - name: Cleanup downloaded nvhpc source
   ansible.builtin.file:
-    path: /opt/quarantine/software/nvhpc/24.3/src
+    path: /opt/quarantine/software/nvhpc/26.3/src
     state: absent
 
 - name: copy nvidia module activate

--- a/roles/science/tasks/qbatch.yml
+++ b/roles/science/tasks/qbatch.yml
@@ -26,4 +26,4 @@
     PIPX_HOME: /opt/pipx
     PIPX_BIN_DIR: /usr/local/bin
   with_items:
-    - qbatch
+    - qbatch==2.3.1


### PR DESCRIPTION
## Software Version Updates (2026Q1)

Individual per-tool commits for reviewability and revertability. 19 commits total: 16 version updates + 3 pre-existing bug fixes discovered during testing.

### Version Updates

| Tool | Old Version | New Version | Notes |
|------|------------|-------------|-------|
| ANTs | 2.5.2 | 2.6.5 | |
| FSL | 6.0.6.4 | 6.0.7.21 | |
| MRtrix3 | 3.0.2 | 3.0.8 | |
| FreeSurfer | 7.4.1 | 7.4.1 + **8.1.0** | Both versions available via module load; mutual conflict prevents simultaneous loading |
| fMRIPrep | 24.1.1, 20.2.8, 25.2.3 | + **25.2.5** | Added alongside existing versions |
| ITK-SNAP | 4.2.4 | **4.4.0** | Platform suffix changed from `Linux-gcc64` to `Linux-x86_64` |
| 3D Slicer | 5.6.2 | **5.10.0** | |
| dcm2niix | v1.0.20230411 | **v1.0.20250506** | |
| DSI-Studio | 2023.05.10 | **2025.04.16** | |
| Connectome Workbench | v1.5.0, v2.0.0 | **v2.1.0** | Removed v1.5.0; fixed pre-existing chmod bug referencing v1.5.0 paths |
| dcm2bids | 3.1.0 | **3.2.0** | |
| Bpipe | 0.9.12 | **0.9.13** | Unified asset naming across cobralab.yml and mri_misc.yml |
| minc2-simple | v2.6.0 (vfonov) | **v2.20.40** (NIST-MNI) | Repo migrated to NIST-MNI/minc2-simple |
| CAT12 | 12.8.2 | **12.9** | |
| NVIDIA HPC SDK | 24.9 | **26.3** | |
| qbatch | unpinned | **2.3.1** | Pinned to specific version |

### Skipped
- **c3d 1.4.6**: No prebuilt binary available; would require building from source

### Bug Fixes (pre-existing, discovered during testing)

1. **`fix(fsl)`: python3 for FSL installer** — FSL 6.0.7.21 installer requires `python3`; old version called `python` which doesn't exist on Ubuntu 24.04
2. **`fix(minc)`: add cmake to build deps** — `cmake` required for minc2-simple C compilation but was missing from dependency list
3. **`fix(containers)`: install software-properties-common** — `apt-add-repository` (used for apptainer PPA) requires `software-properties-common` which was never installed

### Build Verification

| Tag | Status | Notes |
|-----|--------|-------|
| `ants` | Passed | `ANTs Version: 2.6.5-gfdce4d2` |
| `fsl` | Passed | `LICENCE.FSL` verified, `bin/` populated |
| `mrtrix` | Passed | `mrconvert --version` == 3.0.8 |
| `misc` | Partial | ITK-SNAP OK; 3D Slicer download timed out (434MB, infrastructure issue); other misc tools cascaded |
| `minc` | Passed | minc2-simple v2.20.40 built from NIST-MNI/minc2-simple |
| `qbatch` | Passed | `qbatch --version` == 2.3.1 |
| `fmriprep` | In progress | 24.1.1 container built OK; 25.2.3/25.2.5 downloads timed out (multi-GB containers) |
| `freesurfer` | Skipped | Multi-GB download; verified task syntax + module structure |
| `nvidia` | Skipped | Multi-GB download |
| `matlab` | Skipped | Tagged `never` in playbook |

### Files Changed
11 files changed, 151 insertions(+), 91 deletions(-)