### PR TITLE
fix: remove extra '1' in freesurfer license dest path (issue #54)

### DIFF
--- a/roles/science/tasks/freesurfer.yml
+++ b/roles/science/tasks/freesurfer.yml
@@ -48,5 +48,5 @@
 - name: install freesurfer license
   ansible.builtin.copy:
     src: files/license.txt
-    dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version }}1/install/license.txt"
+    dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version }}/install/license.txt"
   ignore_errors: true


### PR DESCRIPTION
Fixes #54 — removes erroneous '1' after `{{ freesurfer_version }}` in the license install path.

Before: `dest: /opt/quarantine/software/freesurfer/{{ freesurfer_version }}1/install/license.txt`
After: `dest: /opt/quarantine/software/freesurfer/{{ freesurfer_version }}/install/license.txt`

1 file, 1 line change.