### PR TITLE
chore(ants): update ANTs 2.6.2 -> 2.6.5

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,6 +1,6 @@
 ---
 # https://github.com/ANTsX/ANTs/releases
-ants_version: 2.6.2
+ants_version: 2.6.5
 
 # Automatic lookup online
 afni_version: "{{ lookup('ansible.builtin.url', 'https://afni.nimh.nih.gov/pub/dist/AFNI.version', wantlist=True)[0] | regex_replace('AFNI_', '')  }}"


### PR DESCRIPTION
Bumps ANTs to 2.6.5 (latest stable; `ubuntu-24.04` asset confirmed).

## Test
libvirt VM install-test, Ubuntu 24.04, `make vm-test TAGS="--tags ants"`:
- Pass 1: changed=11, failed=0
- Pass 2: idempotent (changed=0)
- quarantine dirs verified present

🤖 Generated with [Claude Code](https://claude.com/claude-code)