### PR TITLE
chore(mrtrix): update MRtrix3 3.0.5 -> 3.0.8

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -15,7 +15,7 @@ fsl_version: 6.0.7.13
 freesurfer_version: 7.4.1
 
 # https://github.com/MRtrix3/mrtrix3/releases
-mrtrix3_version: 3.0.5
+mrtrix3_version: 3.0.8
 
 # https://github.com/MRtrix3/mrtrix3.git . Compile latest commit in main
 mrtrix3_dev_version: "{{ (lookup('ansible.builtin.url', 'https://api.github.com/repos/MRtrix3/mrtrix3/commits/HEAD', wantlist=True)[0] | from_json).commit.committer.date | regex_replace('T.*', '') | regex_replace('-','') }}"


### PR DESCRIPTION
Bumps MRtrix3 to 3.0.8 (latest stable, built from source).

## Test
libvirt VM install-test, Ubuntu 24.04, `--tags mrtrix`: Pass1 changed=14 failed=0; Pass2 idempotent (changed=0); quarantine dirs verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)