### PR TITLE
feat(qbatch): pin 2.3.1 via global uv (drop pipx)

### DIFF
--- a/roles/science/tasks/qbatch.yml
+++ b/roles/science/tasks/qbatch.yml
@@ -1,29 +1,15 @@
 ---
 
-# Install pipx
-- name: Install pipx
-  ansible.builtin.apt:
-    update_cache: yes
-    state: present
-    autoclean: yes
-    autoremove: yes
-    pkg: pipx
-
-# pipx directory
-- name: ensure /opt/pipx
-  ansible.builtin.file:
-    path: /opt/pipx
-    state: directory
-    mode: 0755
+# Install Python CLI tools with a global uv + `uv tool install` (not pipx).
+- name: Install uv globally
+  ansible.builtin.shell: curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
+  args:
+    creates: /usr/local/bin/uv
 
 - name: install qbatch
-  community.general.pipx:
-    name: "{{ item }}"
-    state: present
-    inject_packages: "setuptools"
-    include_injected: true
+  ansible.builtin.command: uv tool install --with setuptools qbatch==2.3.1
+  args:
+    creates: /usr/local/bin/qbatch
   environment:
-    PIPX_HOME: /opt/pipx
-    PIPX_BIN_DIR: /usr/local/bin
-  with_items:
-    - qbatch
+    UV_TOOL_DIR: /opt/uv-tools
+    UV_TOOL_BIN_DIR: /usr/local/bin


### PR DESCRIPTION
Pins qbatch to 2.3.1 and switches its install from pipx to a globally installed `uv` + `uv tool install`.

**Why drop pipx:** Ubuntu apt `pipx` is 1.4.3, too old for the modern `community.general.pipx` module (requires >=1.7.0), so the task fails under current ansible-core. Standardized on uv.

## Test
libvirt VM install-test, Ubuntu 24.04, `--tags qbatch`:
- Pass 1 changed=7 failed=0; Pass 2 idempotent (changed=0)
- In-VM: `uv` and `qbatch` on /usr/local/bin; `qbatch --version` == 2.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)