### PR TITLE
feat(mri_misc): dcm2bids 3.1.1 -> 3.2.0 (+ idempotency fix)

### DIFF
--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -16,7 +16,7 @@
     - /opt/quarantine/software/connectome-workbench/v2.0.0/install
     - /opt/quarantine/software/dsi-studio/2023.12.06/install
     - /opt/quarantine/software/c3d/1.4.0/install
-    - /opt/quarantine/software/dcm2bids/3.1.1/install
+    - /opt/quarantine/software/dcm2bids/3.2.0/install
     - /opt/quarantine/software/bpipe/0.9.12/install
 
 ###############################################################################
@@ -245,17 +245,18 @@
 
 - name: Install dcm2bids
   unarchive:
-    src: https://github.com/UNFmontreal/Dcm2Bids/releases/download/3.1.1/dcm2bids_debian-based_3.1.1.tar.gz
-    dest: /opt/quarantine/software/dcm2bids/3.1.1/install
-    creates: /opt/quarantine/software/dcm2bids/3.1.1/install/bin
+    src: https://github.com/UNFmontreal/Dcm2Bids/releases/download/3.2.0/dcm2bids_debian-based_3.2.0.tar.gz
+    dest: /opt/quarantine/software/dcm2bids/3.2.0/install
+    # The tarball lays binaries flat at install root (no bin/ dir); point
+    # creates at a real binary so the task is idempotent.
+    creates: /opt/quarantine/software/dcm2bids/3.2.0/install/dcm2bids
     remote_src: yes
-
     extra_opts:
       - --no-same-owner  # Prevent chown issues in Docker
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/dcm2bids/3.1.1/module
+    dest: /opt/quarantine/software/dcm2bids/3.2.0/module
   notify: link modules
 
 ###############################################################################


### PR DESCRIPTION
Updates dcm2bids 3.1.1 -> **3.2.0**.

Also fixes a pre-existing non-idempotency bug: the release tarball lays its binaries flat at the install root (no `bin/`), but `creates` pointed at `install/bin` which never existed — so the task re-extracted on every run. Now points at the `dcm2bids` binary. The module template already prepends the install root to PATH, so flat binaries resolve.

## Test
In-VM (Ubuntu 24.04, libvirt): extract of `dcm2bids_debian-based_3.2.0.tar.gz`; `dcm2bids --version` -> `3.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)