### PR TITLE
feat(mri_misc): Connectome Workbench -> v2.1.0 (drop v1.5.0)

### DIFF
--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -12,8 +12,7 @@
     - /opt/quarantine/software/dcm2niix/v1.0.20260416/install
     - /opt/quarantine/software/mi-brain/2020.04.09_r2e0ff5/install
     - /opt/quarantine/software/mango/4.1/install
-    - /opt/quarantine/software/connectome-workbench/v1.5.0/install
-    - /opt/quarantine/software/connectome-workbench/v2.0.0/install
+    - /opt/quarantine/software/connectome-workbench/v2.1.0/install
     - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
     - /opt/quarantine/software/dcm2bids/3.2.0/install
@@ -168,40 +167,20 @@
 
 - name: Install connectome-workbench
   ansible.builtin.shell: |
-      curl -s -L -o /tmp/workbench-linux64-v1.5.0.zip \
-      https://www.humanconnectome.org/storage/app/media/workbench/workbench-linux64-v1.5.0.zip
-      bsdtar xzvf /tmp/workbench-linux64-v1.5.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v1.5.0/install
-      rm -f /tmp/workbench-linux64-v1.5.0.zip
-      ln -srf /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin
-      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v1.5.0/install
+      curl -s -L -o /tmp/workbench-linux64-v2.1.0.zip \
+      https://humanconnectome.org/storage/app/media/workbench/workbench-linux64-v2.1.0.zip
+      bsdtar xzvf /tmp/workbench-linux64-v2.1.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v2.1.0/install
+      rm -f /tmp/workbench-linux64-v2.1.0.zip
+      ln -srf /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin
+      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v2.1.0/install
   args:
-    creates: /opt/quarantine/software/connectome-workbench/v1.5.0/install/bin
+    creates: /opt/quarantine/software/connectome-workbench/v2.1.0/install/bin
     executable: /bin/bash
 
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/connectome-workbench/v1.5.0/module
-  notify: link modules
-
-###############################################################################
-
-- name: Install connectome-workbench
-  ansible.builtin.shell: |
-      curl -s -L -o /tmp/workbench-linux64-v2.0.0.zip \
-      https://humanconnectome.org/storage/app/media/workbench/workbench-linux64-v2.0.0.zip
-      bsdtar xzvf /tmp/workbench-linux64-v2.0.0.zip --strip-components 1 -C /opt/quarantine/software/connectome-workbench/v2.0.0/install
-      rm -f /tmp/workbench-linux64-v2.0.0.zip
-      ln -srf /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin_linux64 /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin
-      chmod u=rwX,g=rX,o=rX -R /opt/quarantine/software/connectome-workbench/v1.5.0/install
-  args:
-    creates: /opt/quarantine/software/connectome-workbench/v2.0.0/install/bin
-    executable: /bin/bash
-
-- name: Install module
-  template:
-    src: templates/basemodule.j2
-    dest: /opt/quarantine/software/connectome-workbench/v2.0.0/module
+    dest: /opt/quarantine/software/connectome-workbench/v2.1.0/module
   notify: link modules
 
 ###############################################################################


### PR DESCRIPTION
Consolidates Connectome Workbench to a single **v2.1.0** install (previously v1.5.0 + v2.0.0).

Also fixes a pre-existing bug: the v2.0.0 block's `chmod` referenced the **v1.5.0** install path.

## Test
In-VM (Ubuntu 24.04, libvirt): curl + bsdtar strip-components extract of `workbench-linux64-v2.1.0.zip` (127MB) + bin symlink; `bin/wb_command` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)