### PR TITLE
feat(bpipe): update to 0.9.13

### DIFF
--- a/roles/science/tasks/cobralab.yml
+++ b/roles/science/tasks/cobralab.yml
@@ -8,7 +8,7 @@
     - /opt/quarantine/software/iterativeN3/20230821
     - /opt/quarantine/software/iterativeN4_multispectral/20210503
     - /opt/quarantine/software/minc-bpipe-library/20230721
-    - /opt/quarantine/software/bpipe/0.9.12/install
+    - /opt/quarantine/software/bpipe/0.9.13/install
 
 - name: clone minc-toolkit-extras
   ansible.builtin.git:
@@ -77,9 +77,9 @@
 
 - name: install bpipe
   unarchive:
-    src: https://github.com/ssadedin/bpipe/releases/download/0.9.12/bpipe-0.9.12.tar.gz
-    dest: /opt/quarantine/software/bpipe/0.9.12/install
-    creates: /opt/quarantine/software/bpipe/0.9.12/install/bin/bpipe
+    src: https://github.com/ssadedin/bpipe/releases/download/0.9.13/bpipe-0.9.13.tar.gz
+    dest: /opt/quarantine/software/bpipe/0.9.13/install
+    creates: /opt/quarantine/software/bpipe/0.9.13/install/bin/bpipe
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -88,5 +88,5 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/bpipe/0.9.12/module
+    dest: /opt/quarantine/software/bpipe/0.9.13/module
   notify: link modules

--- a/roles/science/tasks/mri_misc.yml
+++ b/roles/science/tasks/mri_misc.yml
@@ -17,7 +17,7 @@
     - /opt/quarantine/software/dsi-studio/2025.04.16/install
     - /opt/quarantine/software/c3d/1.4.0/install
     - /opt/quarantine/software/dcm2bids/3.2.0/install
-    - /opt/quarantine/software/bpipe/0.9.12/install
+    - /opt/quarantine/software/bpipe/0.9.13/install
 
 ###############################################################################
 
@@ -262,9 +262,9 @@
 
 - name: Install bpipe
   unarchive:
-    src: https://github.com/ssadedin/bpipe/releases/download/0.9.12/bpipe-0.9.12-groovy-3.0.10.tar.gz
-    dest: /opt/quarantine/software/bpipe/0.9.12/install
-    creates: /opt/quarantine/software/bpipe/0.9.12/install/bin/bpipe
+    src: https://github.com/ssadedin/bpipe/releases/download/0.9.13/bpipe-0.9.13.tar.gz
+    dest: /opt/quarantine/software/bpipe/0.9.13/install
+    creates: /opt/quarantine/software/bpipe/0.9.13/install/bin/bpipe
     remote_src: yes
     extra_opts:
       - --strip-components=1
@@ -273,5 +273,5 @@
 - name: Install module
   template:
     src: templates/basemodule.j2
-    dest: /opt/quarantine/software/bpipe/0.9.12/module
+    dest: /opt/quarantine/software/bpipe/0.9.13/module
   notify: link modules


### PR DESCRIPTION
Updates bpipe 0.9.12 -> **0.9.13** in both `cobralab.yml` and `mri_misc.yml`. The new asset dropped the groovy suffix (`bpipe-0.9.13.tar.gz`).

## Test
In-VM (Ubuntu 24.04, libvirt): download + strip-components extract; `bin/bpipe` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)