### PR TITLE
feat(minc): minc2-simple -> NIST-MNI v2.20.40 (+ build-essential/cmake)

### DIFF
--- a/roles/science/tasks/minc.yml
+++ b/roles/science/tasks/minc.yml
@@ -7,7 +7,7 @@
     - /opt/quarantine/software/minc-toolkit-v2/1.9.18/install
     - /opt/quarantine/software/minc-toolkit-v2/1.9.18/src
     - /opt/quarantine/software/minc-stuffs/v0.1.25
-    - /opt/quarantine/software/minc2-simple/v2.2.30/build
+    - /opt/quarantine/software/minc2-simple/v2.20.40/build
 
 - name: Install minc-toolkit-v2 build deps
   apt:
@@ -36,6 +36,8 @@
       - automake
       - cpanminus
       - patchelf
+      - build-essential  # g++/gcc to compile minc-stuffs and minc2-simple
+      - cmake             # required to build minc2-simple
 
 - cpanm: name="Math::Matrix"
 
@@ -121,12 +123,12 @@
 
 - name: clone minc2-simple
   git:
-    repo: https://github.com/vfonov/minc2-simple.git
-    dest: /opt/quarantine/software/minc2-simple/v2.2.30/src
-    version: v2.2.30
+    repo: https://github.com/NIST-MNI/minc2-simple.git
+    dest: /opt/quarantine/software/minc2-simple/v2.20.40/src
+    version: v2.20.40
 
 - name: Install minc2-simple (python)
-  shell: MINC_TOOLKIT=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install micromamba run -r /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base pip install /opt/quarantine/software/minc2-simple/v2.2.30/src/python
+  shell: MINC_TOOLKIT=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install micromamba run -r /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base pip install /opt/quarantine/software/minc2-simple/v2.20.40/src/python
   args:
     creates: /opt/quarantine/software/conda/{{ ansible_date_time.date }}/conda-base/lib/python3.11/site-packages/minc2_simple
   when:
@@ -135,7 +137,7 @@
 - name: Install minc2-simple (C)
   shell: cmake -DCMAKE_INSTALL_PREFIX=/opt/quarantine/software/minc-toolkit-v2/1.9.18/install ../src && make -j {{ ansible_processor_vcpus }} && make install
   args:
-    chdir: /opt/quarantine/software/minc2-simple/v2.2.30/build
+    chdir: /opt/quarantine/software/minc2-simple/v2.20.40/build
     creates: /opt/quarantine/software/minc-toolkit-v2/1.9.18/install/lib/libminc2-simple.so
     executable: /bin/bash
 


### PR DESCRIPTION
- **minc2-simple**: repo migrated `vfonov` -> `NIST-MNI`; bump v2.2.30 -> **v2.20.40**. (v2.21.0 needs a newer libminc than the pinned minc-toolkit 1.9.18 — test link fails on `miget/miset_variable_*` symbols.)
- **Build deps fix**: add `build-essential` (g++/gcc) and `cmake` — the clean Ubuntu base has neither, so minc-stuffs and minc2-simple couldn't compile. The Docker base image had them preinstalled, hiding this.

## Test
libvirt VM install-test, Ubuntu 24.04, `--tags minc`: Pass1 changed=18 failed=0; Pass2 idempotent (changed=0). minc-toolkit-v2 + minc-stuffs + minc2-simple all build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)