### PR TITLE
fix(containers): software-properties-common + idempotent apptainer PPA

### DIFF
--- a/roles/science/tasks/containers.yml
+++ b/roles/science/tasks/containers.yml
@@ -1,9 +1,16 @@
 ---
 
+- name: Install software-properties-common for apt-add-repository
+  ansible.builtin.apt:
+    name: software-properties-common
+    state: present
+    update_cache: true
+
 - name: add apptainer ppa
-  command: apt-add-repository -y -n {{ item }}
-  with_items:
-    - ppa:apptainer/ppa
+  ansible.builtin.apt_repository:
+    repo: ppa:apptainer/ppa
+    state: present
+    update_cache: false
 
 - name: Install apptainer dependencies
   ansible.builtin.apt:


### PR DESCRIPTION
Two fixes to the apptainer/container setup (prereq for fmriprep/fastsurfer/civet builds):

- Install `software-properties-common` (provides `apt-add-repository`) — it was never installed, so container setup failed on a clean system.
- Replace the `command: apt-add-repository` task (always reported *changed*) with the idempotent `ansible.builtin.apt_repository` module.

## Test
libvirt VM install-test, Ubuntu 24.04, `--tags containers`: Pass1 changed=7 failed=0; Pass2 idempotent (changed=0); apptainer installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)