### PR TITLE
feat(fastsurfer): FastSurfer 2.4.2 -> 2.5.4

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -6,7 +6,7 @@ ants_version: 2.6.2
 afni_version: "{{ lookup('ansible.builtin.url', 'https://afni.nimh.nih.gov/pub/dist/AFNI.version', wantlist=True)[0] | regex_replace('AFNI_', '')  }}"
 
 # https://hub.docker.com/r/deepmi/fastsurfer
-fastsurfer_version: 2.4.2
+fastsurfer_version: 2.5.4
 
 # https://fsl.fmrib.ox.ac.uk/fsl/docs/#/development/history/index
 fsl_version: 6.0.7.13


### PR DESCRIPTION
Updates FastSurfer 2.4.2 -> **2.5.4** (latest `cuda-v` tag on Docker Hub).

## Test
In-VM (Ubuntu 24.04, libvirt, apptainer 1.5.1): `apptainer build … docker://deepmi/fastsurfer:cuda-v2.5.4` succeeded — 5.5GB .sif produced at the install path. (Container build needs the apptainer setup from #73.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)