### PR TITLE
feat(fmriprep): add fMRIPrep 25.2.5

### DIFF
--- a/roles/science/tasks/fmriprep.yml
+++ b/roles/science/tasks/fmriprep.yml
@@ -7,6 +7,7 @@
     - /opt/quarantine/software/fmriprep/24.1.1/install
     - /opt/quarantine/software/fmriprep/20.2.8/install
     - /opt/quarantine/software/fmriprep/25.2.3/install
+    - /opt/quarantine/software/fmriprep/25.2.5/install
 
 
 - name: Build fmriprep singularity container
@@ -29,6 +30,17 @@
   template:
     src: templates/basemodule.j2
     dest: /opt/quarantine/software/fmriprep/25.2.3/module
+  notify: link modules
+
+- name: Build fmriprep singularity container
+  command: apptainer build /opt/quarantine/software/fmriprep/25.2.5/install/fmriprep docker://nipreps/fmriprep:25.2.5
+  args:
+    creates: /opt/quarantine/software/fmriprep/25.2.5/install/fmriprep
+
+- name: Install module
+  template:
+    src: templates/basemodule.j2
+    dest: /opt/quarantine/software/fmriprep/25.2.5/module
   notify: link modules
 
 #######LTS Version


### PR DESCRIPTION
Adds fMRIPrep **25.2.5** (latest) alongside existing 24.1.1 / 25.2.3 / 20.2.8 (LTS).

## Test
In-VM (Ubuntu 24.04, libvirt, apptainer 1.5.1): `apptainer build … docker://nipreps/fmriprep:25.2.5` succeeded — 2.4GB .sif produced. (Needs apptainer setup from #73.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)