### PR TITLE
feat(freesurfer): add FreeSurfer 8.2.0 alongside 7.4.1

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -13,6 +13,7 @@ fsl_version: 6.0.7.13
 
 # https://surfer.nmr.mgh.harvard.edu/fswiki/rel7downloads
 freesurfer_version: 7.4.1
+freesurfer_version_v8: 8.2.0
 
 # https://github.com/MRtrix3/mrtrix3/releases
 mrtrix3_version: 3.0.8

--- a/roles/science/tasks/freesurfer.yml
+++ b/roles/science/tasks/freesurfer.yml
@@ -24,6 +24,7 @@
   vars:
     extra_opts:
       - conflict("minc-toolkit-v2")
+      - conflict("freesurfer/8.2.0")
       - prepend_path("PATH", pathJoin(basepath,"fsfast/bin"))
       - prepend_path("PATH", pathJoin(basepath,"tktools"))
       - prepend_path("PATH", pathJoin(basepath,"mni/bin"))
@@ -50,3 +51,72 @@
     src: files/license.txt
     dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version }}/install/license.txt"
   ignore_errors: true
+
+
+###############################################################################
+# FreeSurfer 8.2.0 (separate installation from 7.4.1)
+###############################################################################
+
+- name: Create freesurfer 8.2.0 directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src"
+    - "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install"
+
+- name: Download freesurfer 8.2.0 deb
+  ansible.builtin.get_url:
+    url: "https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/{{ freesurfer_version_v8 }}/freesurfer_ubuntu24-{{ freesurfer_version_v8 }}_amd64.deb"
+    dest: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src
+    timeout: 1800  # ~8.3GB deb over a slow server; default 10s socket timeout is far too short
+
+- name: Extract freesurfer 8.2.0 deb to install directory
+  shell: >
+      dpkg -x freesurfer_ubuntu24-{{ freesurfer_version_v8 }}_amd64.deb /tmp/fs8temp
+      && mv /tmp/fs8temp/usr/local/freesurfer/{{ freesurfer_version_v8 }}/* /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install
+      && rm -rf /tmp/fs8temp
+  args:
+    chdir: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src
+    creates: /opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install/SetUpFreeSurfer.sh
+    executable: /bin/bash
+
+- name: Install module
+  template:
+    src: templates/basemodule.j2
+    dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/module"
+  vars:
+    extra_opts:
+      - conflict("minc-toolkit-v2")
+      - conflict("freesurfer/{{ freesurfer_version }}")
+      - prepend_path("PATH", pathJoin(basepath,"fsfast/bin"))
+      - prepend_path("PATH", pathJoin(basepath,"tktools"))
+      - prepend_path("PATH", pathJoin(basepath,"mni/bin"))
+      - setenv("MINC_BIN_DIR", pathJoin(basepath,"mni/bin"))
+      - setenv("FSFAST_HOME", pathJoin(basepath,"fsfast"))
+      - setenv("FREESURFER", basepath)
+      - setenv("FREESURFER_HOME", basepath)
+      - setenv("MNI_DATAPATH", pathJoin(basepath,"mni/data"))
+      - setenv("FS_OVERRIDE", "0")
+      - setenv("FUNCTIONALS_DIR", pathJoin(basepath,"sessions"))
+      - setenv("MINC_LIB_DIR", pathJoin(basepath,"mni/lib"))
+      - setenv("FMRI_ANALYSIS_DIR", pathJoin(basepath,"fsfast"))
+      - setenv("MNI_DIR", pathJoin(basepath,"mni"))
+      - prepend_path("PERL5LIB", pathJoin(basepath,"mni/share/perl5"))
+      - setenv("MNI_PERL5LIB", pathJoin(basepath,"mni/share/perl5"))
+      - setenv("LOCAL_DIR", pathJoin(basepath,"local"))
+      - setenv("FIX_VERTEX_AREA", "")
+      - setenv("SUBJECTS_DIR", pathJoin(basepath,"subjects"))
+      - setenv("FSF_OUTPUT_FORMAT", "nii.gz")
+  notify: link modules
+
+- name: install freesurfer 8.2.0 license
+  ansible.builtin.copy:
+    src: files/license.txt
+    dest: "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/install/license.txt"
+  ignore_errors: true
+
+- name: Cleanup freesurfer 8.2.0 downloaded deb
+  ansible.builtin.file:
+    path: "/opt/quarantine/software/freesurfer/{{ freesurfer_version_v8 }}/src"
+    state: absent


### PR DESCRIPTION
Adds FreeSurfer **8.2.0** beside the existing 7.4.1 (both loadable via modules; mutual conflict directives).

8.2.0 ships as a `.deb` only (no tar.gz), installed via `dpkg -x` extraction to the quarantine dir. Notes:
- The deb nests under `/usr/local/freesurfer/8.2.0/`, so the `mv` descends into that version subdir (a path #53's untested 8.x block got wrong).
- `get_url timeout: 1800` for the ~8.3GB deb (default 10s socket timeout fails on slow server).

## Test
In-VM (Ubuntu 24.04, libvirt): 7.4.1 installs via full tar (19GB); 8.2.0 deb (8.87GB) downloads + `dpkg -x` + corrected `mv` → `SetUpFreeSurfer.sh` present at install root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)