### PR TITLE
feat(nvidia): NVIDIA HPC SDK 24.3 -> 26.3

### DIFF
--- a/roles/science/tasks/nvidia.yml
+++ b/roles/science/tasks/nvidia.yml
@@ -1,10 +1,18 @@
 ---
+- name: Check if nvhpc is already installed
+  ansible.builtin.stat:
+    path: /opt/quarantine/software/nvhpc/26.3/install/modulefiles
+  register: nvhpc_installed
+
 - name: Create nvidia module directories
   file:
     path: "{{ item }}"
     state: directory
   loop:
-    - /opt/quarantine/software/nvhpc/24.3/src
+    - /opt/quarantine/software/nvhpc/26.3/src
+  # Skip once installed: otherwise this recreates src (deleted by cleanup) and
+  # the cleanup task deletes it again every run -> non-idempotent ping-pong.
+  when: not nvhpc_installed.stat.exists
 
 - name: Install nvidia development dependencies
   ansible.builtin.apt:
@@ -25,22 +33,22 @@
 
 - name: Download nvhpc
   unarchive:
-    src: https://developer.download.nvidia.com/hpc-sdk/24.3/nvhpc_2024_243_Linux_x86_64_cuda_multi.tar.gz
-    dest: /opt/quarantine/software/nvhpc/24.3/src
-    creates: /opt/quarantine/software/nvhpc/24.3/install/modulefiles # We rely on a file created by the installation so this isn't re-downloaded
+    src: https://developer.download.nvidia.com/hpc-sdk/26.3/nvhpc_2026_263_Linux_x86_64_cuda_multi.tar.gz
+    dest: /opt/quarantine/software/nvhpc/26.3/src
+    creates: /opt/quarantine/software/nvhpc/26.3/install/modulefiles # We rely on a file created by the installation so this isn't re-downloaded
     remote_src: yes
     extra_opts:
       - --strip-components=1
       - --no-same-owner  # Prevent chown issues in Docker
 
 - name: Run nvhpc Installer
-  ansible.builtin.shell: NVHPC_SILENT=true NVHPC_INSTALL_DIR=/opt/quarantine/software/nvhpc/24.3/install NVHPC_INSTALL_TYPE=auto /opt/quarantine/software/nvhpc/24.3/src/install
+  ansible.builtin.shell: NVHPC_SILENT=true NVHPC_INSTALL_DIR=/opt/quarantine/software/nvhpc/26.3/install NVHPC_INSTALL_TYPE=auto /opt/quarantine/software/nvhpc/26.3/src/install
   args:
-    creates: /opt/quarantine/software/nvhpc/24.3/install/modulefiles
+    creates: /opt/quarantine/software/nvhpc/26.3/install/modulefiles
 
 - name: Cleanup downloaded nvhpc source
   ansible.builtin.file:
-    path: /opt/quarantine/software/nvhpc/24.3/src
+    path: /opt/quarantine/software/nvhpc/26.3/src
     state: absent
 
 - name: copy nvidia module activate


### PR DESCRIPTION
Updates NVIDIA HPC SDK 24.3 -> **26.3** (cuda_multi tarball). Also fixes a pre-existing non-idempotency: the src-dir creation ping-ponged with the cleanup task (create src -> cleanup deletes -> recreate, every run); now gated on the install marker.

## Test
libvirt VM install-test, Ubuntu 24.04 (100G disk): fresh install changed=11 failed=0 (~13GB download, ~25GB install); re-run idempotent (changed=0). Note: needs >~60GB free for the src+install peak (the SDK grew vs 24.3). `never`-tagged (GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)